### PR TITLE
Minimax: Maximale Rekursionstiefe

### DIFF
--- a/jupyter/muehle-minimax.ipynb
+++ b/jupyter/muehle-minimax.ipynb
@@ -69,7 +69,7 @@
     "    count += 1\n",
     "    if finished(s):\n",
     "        return utility(s, p)\n",
-    "    if count > 10:\n",
+    "    if count > 3:\n",
     "        return 0\n",
     "    return max([-value(ps, opponent(p), count) for ns in nextStates(s, p)])"
    ]


### PR DESCRIPTION
Fixes #38.
Für die Messungen wurde State `s0` verwendet, bei dem das Board leer ist, dadurch ensteht ein großer Branching Faktor.

* `max = 1`
  > CPU times: user 63.7 ms, sys: 0 ns, total: 63.7 ms
  > Wall time: 60 ms
* `max = 2`
  > CPU times: user 1.19 s, sys: 0 ns, total: 1.19 s
  > Wall time: 1.19 s
* `max = 3`
  > CPU times: user 12.9 s, sys: 25.5 ms, total: 12.9 s
  > Wall time: 12.9 s
* `max = 4`
  > CPU times: user 2min 17s, sys: 516 ms, total: 2min 17s
  > Wall time: 2min 17s