### PR TITLE
Minimax: Falscher Variablenname und falsch verwendete Funktionssignatur

### DIFF
--- a/jupyter/muehle-minimax.ipynb
+++ b/jupyter/muehle-minimax.ipynb
@@ -71,7 +71,7 @@
     "        return utility(s, p)\n",
     "    if count > 10:\n",
     "        return 0\n",
-    "    return max([-value(ps, opponent(p), count) for ns in nextStates(s, p)])"
+    "    return max([-value(ns, opponent(p), count) for ns in nextStates(s, p)])"
    ]
   },
   {
@@ -91,8 +91,8 @@
    "source": [
     "def bestMove(s, p):\n",
     "    ns = nextStates(s, p)\n",
-    "    bestValue = value(s, p)\n",
-    "    bestMoves = [s for s in ns if -value(s, opponent(p)) == bestValue]\n",
+    "    bestValue = value(s, p, 0)\n",
+    "    bestMoves = [s for s in ns if -value(s, opponent(p), 0) == bestValue]\n",
     "    return bestValue, bestMoves[0]"
    ]
   }


### PR DESCRIPTION
Fixes #49
Wie der Name schon sagt, nichts besonderes.