### PR TITLE
Symmetrie Erkennung für AlphaBeta

### DIFF
--- a/jupyter/nmm-alpha-beta-pruning.ipynb
+++ b/jupyter/nmm-alpha-beta-pruning.ipynb
@@ -29,7 +29,32 @@
    "outputs": [],
    "source": [
     "%run ./nmm-game.ipynb\n",
-    "%run ./nmm-heuristic.ipynb"
+    "%run ./nmm-heuristic.ipynb\n",
+    "%run ./nmm-symmetry.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Die Hilfsfunktion `writeCache_AB` legt den gegebenen Zustand `state` mit samt der errechneten Werte `value`, `alpha` und `beta` im Cache ab. Ist zusätzlich der Parameter `symmetry` als `True` gesetzt, werden die errechneten Werte ebenfalls für alle symmetrischen Zustände gespeichert."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def writeCache_AB(state, value, alpha, beta, symmetry=True):\n",
+    "    global Cache\n",
+    "    \n",
+    "    # If symmetry is enabled, find all symmetic states and save them too\n",
+    "    if symmetry:\n",
+    "        for symmetricState in findSymmetries(state):\n",
+    "            Cache[symmetricState] = (value, alpha, beta)\n",
+    "    else:\n",
+    "        Cache[state] = (value, alpha, beta)"
    ]
   },
   {
@@ -49,7 +74,7 @@
    "source": [
     "Cache = {}\n",
     "\n",
-    "def value_AB(s, p, limit, alpha=-1, beta=1):\n",
+    "def value_AB(s, p, limit, symmetry=True, alpha=-1, beta=1):\n",
     "    global Cache\n",
     "    if s in Cache:\n",
     "        (val, a, b) = Cache[s]\n",
@@ -58,12 +83,12 @@
     "        else:\n",
     "            alpha = min(alpha, a)\n",
     "            beta  = max(beta , b)\n",
-    "            val   = alphaBeta(s, p, limit, alpha, beta)\n",
-    "            Cache[s] = (val, alpha, beta)\n",
+    "            val   = alphaBeta(s, p, limit, alpha, beta, symmetry=symmetry)\n",
+    "            writeCache_AB(s, val, alpha, beta, symmetry=symmetry)\n",
     "            return val\n",
     "    else:\n",
-    "        val = alphaBeta(s, p, limit, alpha, beta)\n",
-    "        Cache[s] = (val, alpha, beta)\n",
+    "        val = alphaBeta(s, p, limit, alpha, beta, symmetry=symmetry)\n",
+    "        writeCache_AB(s, val, alpha, beta, symmetry=symmetry)\n",
     "        return val"
    ]
   },
@@ -84,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def alphaBeta(s, p, limit, alpha, beta):\n",
+    "def alphaBeta(s, p, limit, alpha, beta, symmetry=True):\n",
     "    states = nextStates(s, p)\n",
     "    if finished(s, p, ns=states):\n",
     "        return utility(s, p)\n",
@@ -92,7 +117,7 @@
     "        return heuristic(s, p)\n",
     "    val = alpha\n",
     "    for ns in states:\n",
-    "        val = max(val, -value_AB(ns, opponent(p), limit-1, -beta, -alpha))\n",
+    "        val = max(val, -value_AB(ns, opponent(p), limit-1, symmetry=symmetry, beta=-beta, alpha=-alpha))\n",
     "        if val >= beta:\n",
     "            return val\n",
     "        alpha = max(val, alpha)\n",
@@ -114,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def bestMove_AB(s, p, limit = None, visited = set()):\n",
+    "def bestMove_AB(s, p, limit=None, visited=set(), symmetry=True):\n",
     "    if limit is None:\n",
     "        limit = 3\n",
     "    # Clear cache\n",
@@ -122,7 +147,7 @@
     "    Cache = {}\n",
     "\n",
     "    moves = [\n",
-    "        (-value_AB(s, opponent(p), limit), s)\n",
+    "        (-value_AB(s, opponent(p), limit, symmetry=symmetry), s)\n",
     "        for s in nextStates(s, p) if s not in visited\n",
     "    ]\n",
     "    return max(moves, key=lambda m: m[0])"
@@ -145,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/jupyter/nmm-alpha-beta-pruning.ipynb
+++ b/jupyter/nmm-alpha-beta-pruning.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "Cache = {}\n",
     "\n",
-    "def value_AB(s, p, limit, symmetry=True, alpha=-1, beta=1):\n",
+    "def value_AB(s, p, alpha=-1, beta=1, limit=3, symmetry=True):\n",
     "    global Cache\n",
     "    if s in Cache:\n",
     "        (val, a, b) = Cache[s]\n",
@@ -83,11 +83,11 @@
     "        else:\n",
     "            alpha = min(alpha, a)\n",
     "            beta  = max(beta , b)\n",
-    "            val   = alphaBeta(s, p, limit, alpha, beta, symmetry=symmetry)\n",
+    "            val   = alphaBeta(s, p, alpha, beta, limit=limit, symmetry=symmetry)\n",
     "            writeCache_AB(s, val, alpha, beta, symmetry=symmetry)\n",
     "            return val\n",
     "    else:\n",
-    "        val = alphaBeta(s, p, limit, alpha, beta, symmetry=symmetry)\n",
+    "        val = alphaBeta(s, p, alpha, beta, limit=limit, symmetry=symmetry)\n",
     "        writeCache_AB(s, val, alpha, beta, symmetry=symmetry)\n",
     "        return val"
    ]
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def alphaBeta(s, p, limit, alpha, beta, symmetry=True):\n",
+    "def alphaBeta(s, p, alpha, beta, limit=3, symmetry=True):\n",
     "    states = nextStates(s, p)\n",
     "    if finished(s, p, ns=states):\n",
     "        return utility(s, p)\n",
@@ -117,7 +117,7 @@
     "        return heuristic(s, p)\n",
     "    val = alpha\n",
     "    for ns in states:\n",
-    "        val = max(val, -value_AB(ns, opponent(p), limit-1, symmetry=symmetry, beta=-beta, alpha=-alpha))\n",
+    "        val = max(val, -value_AB(ns, opponent(p), -beta, -alpha, limit=limit-1, symmetry=symmetry))\n",
     "        if val >= beta:\n",
     "            return val\n",
     "        alpha = max(val, alpha)\n",
@@ -147,8 +147,9 @@
     "    Cache = {}\n",
     "\n",
     "    moves = [\n",
-    "        (-value_AB(s, opponent(p), limit, symmetry=symmetry), s)\n",
-    "        for s in nextStates(s, p) if s not in visited\n",
+    "        (-value_AB(s, opponent(p), limit=limit, symmetry=symmetry), s)\n",
+    "        for s in nextStates(s, p)\n",
+    "        if s not in visited\n",
     "    ]\n",
     "    return max(moves, key=lambda m: m[0])"
    ]

--- a/jupyter/nmm-alpha-beta-pruning.ipynb
+++ b/jupyter/nmm-alpha-beta-pruning.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Die Hilfsfunktion `writeCache_AB` legt den gegebenen Zustand `state` mit samt der errechneten Werte `value`, `alpha` und `beta` im Cache ab. Ist zusätzlich der Parameter `symmetry` als `True` gesetzt, werden die errechneten Werte ebenfalls für alle symmetrischen Zustände gespeichert."
+    "Die Hilfsfunktion `writeCache_AB` legt den gegebenen Zustand `state` mit samt der errechneten Werte `value`, `alpha` und `beta` im Cache ab. Ist zusätzlich der Parameter `symmetry` auf `True` gesetzt, werden die errechneten Werte ebenfalls für alle symmetrischen Zustände gespeichert."
    ]
   },
   {

--- a/jupyter/nmm-symmetry.ipynb
+++ b/jupyter/nmm-symmetry.ipynb
@@ -8,7 +8,7 @@
     "# Symmetrie\n",
     "Um das Caching noch effektiver zu gestalten, sollen neben Transpositionen auch Symmetrien erkannt werden. In diesem Kapitel werden alle Funktionen, die für die Symmetrieerkennung nötig sind, vorgestellt und implementiert.\n",
     "\n",
-    "Zunächst werden Hilfsfunktion definiert, die auf ein gegebenen Spielbrettern (`boards`) eine bestimmte Symmetrie anwenden alle resultierenden Spielbretter in einer Menge (`Set`) zurück geben. Schlussendlich werden alle Symmetrien nacheinander angewandte, damit auch zusammengesetzte Symetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` errechnet werden."
+    "Zunächst werden Hilfsfunktion definiert, die auf den gegebenen Spielbrettern (`boards`) eine bestimmte Symmetrie anwenden und alle resultierenden Spielbretter in einer Menge (`Set`) zurück geben. Schlussendlich werden alle Symmetrien nacheinander angewandt, damit auch zusammengesetzte Symetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` errechnet werden."
    ]
   },
   {
@@ -45,8 +45,8 @@
     "## Rotation\n",
     "Ein Spielbrett kann um 90°, 180° oder 270° gedreht werden, die resultierenden Spielbretter sind rotationssymmetrisch.\n",
     "\n",
-    "Die Eingabe besteht aus einem einzelnen Spielbrett (`board`), die Ausgabe ist eine Menge, die maximal aus drei Spielbrettern besteht, die rotationssymmetrisch zu der Eingabe sind.\n",
-    "Berechnet wird die Ausgabe indem alle Ringe um `k ∈ {2, 4, 6}` Zellen rotiert werden. Durch Aneinanderreihung der letzten `8-k` Zellen und der ersten `k` Zellen kommt die Rotation zustande."
+    "Die Eingabe besteht aus einer Menge von Spielbrettern (`boards`), die Ausgabe ist ebenfalls eine Menge, die alle Spielbretter enthält, die rotationssymmetrisch zu der Eingabe sind.\n",
+    "Berechnet wird die Ausgabe indem alle Ringe um $k \\in {2, 4, 6}$ Zellen rotiert werden. Durch Aneinanderreihung der letzten $8-k$ Zellen und der ersten $k$ Zellen kommt die Rotation zustande."
    ]
   },
   {
@@ -77,7 +77,7 @@
     "* die *horizontale* und *vertikale* Achse, sowie\n",
     "* die Diagonale von oben links nach unten rechts (*negative Diagonale*) und die Diagonale von unten links nach oben rechts (*positive Diagnonale*).\n",
     "\n",
-    "Diese Spiegelungen können einzelnt pro Ring vorgenommen werden, da der äußere Ring bleibt nach der Spiegelung weiterhin der äußere Ring. Gleiches gilt für die anderen Ringe. Alle Spiegelungen lassen sich durch eine Invertierung der Ringe und eine Rotation von `k ∈ {0, 2, 4, 6}` darstellen."
+    "Diese Spiegelungen können einzelnd pro Ring vorgenommen werden, da der äußere Ring bleibt nach der Spiegelung weiterhin der äußere Ring. Gleiches gilt für die anderen Ringe. Alle Spiegelungen lassen sich durch eine Invertierung der Ringe und eine Rotation von $k \\in {0, 2, 4, 6}$ darstellen."
    ]
   },
   {
@@ -192,7 +192,7 @@
    "metadata": {},
    "source": [
     "## Zusammenführung\n",
-    "Damit alle möglichen Symmetrien gefunden werden, wird jede Hilfsfunktion einzelnt auf alle vorherigen Spielbretter (`boards`) oder Zustände (`states`) angewandt. Dadurch sind auch zusammengesetzte Symmetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` möglich. Mit Hilfe einer Menge wird sichergestellt, dass keine Duplikate zurück gegeben werden."
+    "Damit alle möglichen Symmetrien gefunden werden, wird jede Hilfsfunktion einzelnd auf alle vorherigen Spielbretter (`boards`) oder Zustände (`states`) angewandt. Dadurch sind auch zusammengesetzte Symmetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` möglich. Mit Hilfe einer Menge wird sichergestellt, dass keine Duplikate zurück gegeben werden."
    ]
   },
   {

--- a/jupyter/nmm-symmetry.ipynb
+++ b/jupyter/nmm-symmetry.ipynb
@@ -8,8 +8,7 @@
     "# Symmetrie\n",
     "Um das Caching noch effektiver zu gestalten, sollen neben Transpositionen auch Symmetrien erkannt werden. In diesem Kapitel werden alle Funktionen, die für die Symmetrieerkennung nötig sind, vorgestellt und implementiert.\n",
     "\n",
-    "Zunächst werden Hilfsfunktion definiert, die auf ein gegebenen Spielbrettern (`boards`) eine bestimmte Symmetrie anwenden alle resultierenden Spielbretter in einer Menge (`Set`) zurück geben. Eine weitere Hilfsfunktion wendet auf Zustände (`states`) eine weitere Symmetrie an.\n",
-    "Schlussendlich werden alle Symmetrien nacheinander angewandte, damit auch zusammengesetzte Symetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` errechnet werden."
+    "Zunächst werden Hilfsfunktion definiert, die auf ein gegebenen Spielbrettern (`boards`) eine bestimmte Symmetrie anwenden alle resultierenden Spielbretter in einer Menge (`Set`) zurück geben. Schlussendlich werden alle Symmetrien nacheinander angewandte, damit auch zusammengesetzte Symetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` errechnet werden."
    ]
   },
   {
@@ -189,47 +188,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hollow-onion",
-   "metadata": {},
-   "source": [
-    "## Spieler-Tausch\n",
-    "Die Spieler können ebenfalls vertauscht werden. Wichtig hierbei ist allerdings, dass auch die Steine im `Stash` getauscht werden. Deshalb muss benötigt diese Hilfsfunktion den gesamten Zustand und nicht nur ein einzelnes Spielbrett.\n",
-    "\n",
-    "Durch einfaches tauschen des `Stash` und Iteration über alle Zellen, bei der jeder Stein mit dem gegnerischen Stein ausgetauscht wird, lässt sich diese Funktion implementieren."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "pleasant-definition",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def symmetryPlayer(states):\n",
-    "    return {\n",
-    "        (\n",
-    "            (stash[1], stash[0]),\n",
-    "            tuple(\n",
-    "                tuple(\n",
-    "                    ' ' if cell == ' ' else opponent(cell)\n",
-    "                    for cell in ring\n",
-    "                )\n",
-    "                for ring in board\n",
-    "            )\n",
-    "        )\n",
-    "        for stash, board in states\n",
-    "    }"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "increasing-neutral",
    "metadata": {},
    "source": [
     "## Zusammenführung\n",
-    "Damit alle möglichen Symmetrien gefunden werden, wird jede Hilfsfunktion einzelnt auf alle vorherigen Spielbretter (`boards`) oder Zustände (`states`) angewandt. Dadurch sind auch zusammengesetzte Symmetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` möglich. Mit Hilfe einer Menge wird sichergestellt, dass keine Duplikate zurück gegeben werden.\n",
-    "\n",
-    "Da nicht alle Symmetrie-Hilfsfunktionen den gesamten Zustand brauchen, werden zunächst einmal alle Funktionen angewandt, die nur das Spielbrett benötigen. Daraufhin wird die letzte Symmetrie angewandt, die Zustände als Eingabe benötigt."
+    "Damit alle möglichen Symmetrien gefunden werden, wird jede Hilfsfunktion einzelnt auf alle vorherigen Spielbretter (`boards`) oder Zustände (`states`) angewandt. Dadurch sind auch zusammengesetzte Symmetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` möglich. Mit Hilfe einer Menge wird sichergestellt, dass keine Duplikate zurück gegeben werden."
    ]
   },
   {
@@ -250,12 +213,10 @@
     "    boards |= symmetryDiagnoalNegative(boards)\n",
     "    boards |= symmetryRing(boards)\n",
     "    \n",
-    "    states = {\n",
+    "    return {\n",
     "        (stash, board)\n",
     "        for board in boards\n",
-    "    }\n",
-    "    states |= symmetryPlayer(states)\n",
-    "    return states"
+    "    }"
    ]
   }
  ],

--- a/jupyter/nmm-symmetry.ipynb
+++ b/jupyter/nmm-symmetry.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "demonstrated-delivery",
+   "metadata": {},
+   "source": [
+    "# Symmetrie\n",
+    "Um das Caching noch effektiver zu gestalten, sollen neben Transpositionen auch Symmetrien erkannt werden. In diesem Kapitel werden alle Funktionen, die für die Symmetrieerkennung nötig sind, vorgestellt und implementiert.\n",
+    "\n",
+    "Zunächst werden Hilfsfunktion definiert, die auf ein gegebenen Spielbrettern (`boards`) eine bestimmte Symmetrie anwenden alle resultierenden Spielbretter in einer Menge (`Set`) zurück geben. Eine weitere Hilfsfunktion wendet auf Zustände (`states`) eine weitere Symmetrie an.\n",
+    "Schlussendlich werden alle Symmetrien nacheinander angewandte, damit auch zusammengesetzte Symetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` errechnet werden."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "elder-enlargement",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os.path\n",
+    "css = \"\"\n",
+    "if os.path.isfile(\"style.html\"):\n",
+    "    from IPython.core.display import HTML\n",
+    "    with open(\"style.html\", \"r\") as file:\n",
+    "        css = file.read()\n",
+    "HTML(css)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "peaceful-smooth",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run ./nmm-game-utils.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "british-mount",
+   "metadata": {},
+   "source": [
+    "## Rotation\n",
+    "Ein Spielbrett kann um 90°, 180° oder 270° gedreht werden, die resultierenden Spielbretter sind rotationssymmetrisch.\n",
+    "\n",
+    "Die Eingabe besteht aus einem einzelnen Spielbrett (`board`), die Ausgabe ist eine Menge, die maximal aus drei Spielbrettern besteht, die rotationssymmetrisch zu der Eingabe sind.\n",
+    "Berechnet wird die Ausgabe indem alle Ringe um `k ∈ {2, 4, 6}` Zellen rotiert werden. Durch Aneinanderreihung der letzten `8-k` Zellen und der ersten `k` Zellen kommt die Rotation zustande."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "electronic-interview",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def symmetryRotation(boards):\n",
+    "    return {\n",
+    "        tuple(\n",
+    "            board[ring][rotation:] + board[ring][:rotation]\n",
+    "            for ring in range(3)\n",
+    "        )\n",
+    "        for rotation in range(2, 6+1, 2)\n",
+    "        for board in boards\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "simplified-lawrence",
+   "metadata": {},
+   "source": [
+    "## Spiegelung\n",
+    "Bei den Spiegelungen wird an vier Achsen gespiegelt:\n",
+    "* die *horizontale* und *vertikale* Achse, sowie\n",
+    "* die Diagonale von oben links nach unten rechts (*negative Diagonale*) und die Diagonale von unten links nach oben rechts (*positive Diagnonale*).\n",
+    "\n",
+    "Diese Spiegelungen können einzelnt pro Ring vorgenommen werden, da der äußere Ring bleibt nach der Spiegelung weiterhin der äußere Ring. Gleiches gilt für die anderen Ringe. Alle Spiegelungen lassen sich durch eine Invertierung der Ringe und eine Rotation von `k ∈ {0, 2, 4, 6}` darstellen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "formal-commerce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def symmetryHorizontal(boards):\n",
+    "    return {\n",
+    "        tuple(\n",
+    "            tuple(\n",
+    "                board[ring][(8-(cell+2))%8]\n",
+    "                for cell in range(8)\n",
+    "            )\n",
+    "            for ring in range(3)\n",
+    "        )\n",
+    "        for board in boards\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "italian-breast",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def symmetryVertical(boards):\n",
+    "    return {\n",
+    "        tuple(\n",
+    "            tuple(\n",
+    "                board[ring][(8-(cell+6))%8]\n",
+    "                for cell in range(8)\n",
+    "            )\n",
+    "            for ring in range(3)\n",
+    "        )\n",
+    "        for board in boards\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "persistent-webcam",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def symmetryDiagonalPositive(boards):\n",
+    "    return {\n",
+    "        tuple(\n",
+    "            tuple(\n",
+    "                board[ring][(8-(cell+4))%8]\n",
+    "                for cell in range(8)\n",
+    "            )\n",
+    "            for ring in range(3)\n",
+    "        )\n",
+    "        for board in boards\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "forty-longitude",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def symmetryDiagnoalNegative(boards):\n",
+    "    return {\n",
+    "        tuple(\n",
+    "            tuple(\n",
+    "                board[ring][(8-cell)%8]\n",
+    "                for cell in range(8)\n",
+    "            )\n",
+    "            for ring in range(3)\n",
+    "        )\n",
+    "        for board in boards\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "changed-opposition",
+   "metadata": {},
+   "source": [
+    "## Ring-Tausch\n",
+    "Da der innere und der äußere Ring über symmetrische Kanten mit dem mittleren Ring verbunden ist, können der äußere und der innere Ringe getauscht werden. Dies funktioniert indem rückwärts über die Ringe iteriert wird."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "constant-association",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def symmetryRing(boards):\n",
+    "    return {\n",
+    "        tuple(\n",
+    "            board[ring]\n",
+    "            for ring in reversed(range(3))\n",
+    "        )\n",
+    "        for board in boards\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hollow-onion",
+   "metadata": {},
+   "source": [
+    "## Spieler-Tausch\n",
+    "Die Spieler können ebenfalls vertauscht werden. Wichtig hierbei ist allerdings, dass auch die Steine im `Stash` getauscht werden. Deshalb muss benötigt diese Hilfsfunktion den gesamten Zustand und nicht nur ein einzelnes Spielbrett.\n",
+    "\n",
+    "Durch einfaches tauschen des `Stash` und Iteration über alle Zellen, bei der jeder Stein mit dem gegnerischen Stein ausgetauscht wird, lässt sich diese Funktion implementieren."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pleasant-definition",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def symmetryPlayer(states):\n",
+    "    return {\n",
+    "        (\n",
+    "            (stash[1], stash[0]),\n",
+    "            tuple(\n",
+    "                tuple(\n",
+    "                    ' ' if cell == ' ' else opponent(cell)\n",
+    "                    for cell in ring\n",
+    "                )\n",
+    "                for ring in board\n",
+    "            )\n",
+    "        )\n",
+    "        for stash, board in states\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "increasing-neutral",
+   "metadata": {},
+   "source": [
+    "## Zusammenführung\n",
+    "Damit alle möglichen Symmetrien gefunden werden, wird jede Hilfsfunktion einzelnt auf alle vorherigen Spielbretter (`boards`) oder Zustände (`states`) angewandt. Dadurch sind auch zusammengesetzte Symmetrien wie beispielsweise `Rotation um 90°` dann `Spiegelung an der horizontalen Achse` möglich. Mit Hilfe einer Menge wird sichergestellt, dass keine Duplikate zurück gegeben werden.\n",
+    "\n",
+    "Da nicht alle Symmetrie-Hilfsfunktionen den gesamten Zustand brauchen, werden zunächst einmal alle Funktionen angewandt, die nur das Spielbrett benötigen. Daraufhin wird die letzte Symmetrie angewandt, die Zustände als Eingabe benötigt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "continent-jefferson",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def findSymmetries(state):\n",
+    "    stash, board = state\n",
+    "    \n",
+    "    boards = { board }\n",
+    "    boards |= symmetryRotation(boards)\n",
+    "    boards |= symmetryHorizontal(boards)\n",
+    "    boards |= symmetryVertical(boards)\n",
+    "    boards |= symmetryDiagonalPositive(boards)\n",
+    "    boards |= symmetryDiagnoalNegative(boards)\n",
+    "    boards |= symmetryRing(boards)\n",
+    "    \n",
+    "    states = {\n",
+    "        (stash, board)\n",
+    "        for board in boards\n",
+    "    }\n",
+    "    states |= symmetryPlayer(states)\n",
+    "    return states"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Dieser PR implementiert Symmetrie Erkennung für AlphaBeta-Pruning, diese Einstellung ist vorerst nicht für Minimax verfügbar.

Part of #98