### PR TITLE
#126: fix order of orderMove(s, p)

### DIFF
--- a/jupyter/nmm-alpha-beta-pruning.ipynb
+++ b/jupyter/nmm-alpha-beta-pruning.ipynb
@@ -120,7 +120,7 @@
    "source": [
     "def orderMove(ns, p):\n",
     "    global OldCache\n",
-    "    return sorted(ns, key = lambda s: OldCache.get((s, p), (0, -1, 1))[0])"
+    "    return sorted(ns, key = lambda s: OldCache.get((s, p), (0, -1, 1))[0], reverse=True)"
    ]
   },
   {
@@ -255,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
closes #126 

Laut https://docs.python.org/3/howto/sorting.html wird default aufsteigend sortiert. Also einmal reversed