### PR TITLE
Added counter for invalid cache hits with AlphaBeta

### DIFF
--- a/jupyter/nmm-alpha-beta-pruning.ipynb
+++ b/jupyter/nmm-alpha-beta-pruning.ipynb
@@ -242,8 +242,8 @@
     "* `visited` ist die Anzahl der besuchten Zustände;\n",
     "* `max_states` ist die Anzahl der maximal zu besuchenden Zustände;\n",
     "* `cache_hit` ist die Anzahl der Berechenungen, die durch die Tanspositionstabelle (`cache`) eingespart werden konnten;\n",
-    "* `cache_invalid` ist die Anzahl der Berechnungen, die trotz der Transpositionstable durchgeführt werden mussten, obwohl ein Wert gespeichert wurde, dieser jedoch unbrauchbar war;\n",
-    "* `cache_miss` ist die Anzahl der Berechnungen, die trotz der Transpositionstable durchgeführt werden mussten, da kein Eintrag gefunden wurde."
+    "* `cache_invalid` ist die Anzahl der Berechnungen, die durchgeführt werden mussten, da der in der Transpositionstabelle vorhandene Wert nicht zu verwenden war;\n",
+    "* `cache_miss` ist die Anzahl der Berechnungen, die trotz der Transpositionstabelle durchgeführt werden mussten, da kein Eintrag gefunden wurde."
    ]
   },
   {

--- a/jupyter/nmm-alpha-beta-pruning.ipynb
+++ b/jupyter/nmm-alpha-beta-pruning.ipynb
@@ -178,7 +178,7 @@
     "            beta  = max(beta , b)\n",
     "            val   = self.alphaBeta(state, player, alpha, beta, limit)\n",
     "            self.writeCache(state, player, val, alpha, beta, limit)\n",
-    "            self.cache_miss += 1\n",
+    "            self.cache_invalid += 1\n",
     "            return val\n",
     "    else:\n",
     "        val = self.alphaBeta(state, player, alpha, beta, limit)\n",
@@ -242,7 +242,8 @@
     "* `visited` ist die Anzahl der besuchten Zustände;\n",
     "* `max_states` ist die Anzahl der maximal zu besuchenden Zustände;\n",
     "* `cache_hit` ist die Anzahl der Berechenungen, die durch die Tanspositionstabelle (`cache`) eingespart werden konnten;\n",
-    "* `cache_miss` ist die Anzahl der Berechnungen, die trotz der Transpositionstable durchgeführt werden mussten."
+    "* `cache_invalid` ist die Anzahl der Berechnungen, die trotz der Transpositionstable durchgeführt werden mussten, obwohl ein Wert gespeichert wurde, dieser jedoch unbrauchbar war;\n",
+    "* `cache_miss` ist die Anzahl der Berechnungen, die trotz der Transpositionstable durchgeführt werden mussten, da kein Eintrag gefunden wurde."
    ]
   },
   {
@@ -258,6 +259,7 @@
     "    # Reset counter\n",
     "    self.visited = 0\n",
     "    self.cache_hit = 0\n",
+    "    self.cache_invalid = 0\n",
     "    self.cache_miss = 0\n",
     "    \n",
     "    states = nextStates(state, player)\n",
@@ -287,6 +289,7 @@
     "            \"visited\": self.visited,\n",
     "            \"max_states\": self.max_states,\n",
     "            \"cache_hit\": self.cache_hit,\n",
+    "            \"cache_invalid\": self.cache_invalid,\n",
     "            \"cache_miss\": self.cache_miss,   }\n",
     "    )\n",
     "\n",
@@ -311,7 +314,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Bei den Debug Informationen von Alpha-Beta-Pruning ist mir aufgefallen, dass wir bei einem Cache Miss nicht unterscheiden können, ob es einfach nicht im Cache war oder ob der Cache nicht verwendet werden konnte.