### PR TITLE
Fix: Cache.clean() start min_limit always as 0

### DIFF
--- a/jupyter/nmm-alpha-beta-pruning.ipynb
+++ b/jupyter/nmm-alpha-beta-pruning.ipynb
@@ -367,7 +367,6 @@
     "            \"cache_invalid\": self.cache_invalid,\n",
     "            \"cache_miss\": self.cache_miss,   \n",
     "            \"cache_size\": len(self.cache.cache),\n",
-    "            \"cache_min_limit\": self.cache.min_limit,\n",
     "            \"cache_cleaned\": cleaned}\n",
     "    )\n",
     "\n",

--- a/jupyter/nmm-cache.ipynb
+++ b/jupyter/nmm-cache.ipynb
@@ -30,9 +30,8 @@
    "metadata": {},
    "source": [
     "## Cache\n",
-    "Die Klasse `Cache` implementiert eine Transpositionstabelle die persistiert werden kann. Der Konstruktor erhält folgende Parameter: \n",
-    "- `max_size` gibt an, wie viele Einträge sich maximal im Cache befinden dürfen, bevor `min_limit` erhöht wird und Einträge entfernt werden.\n",
-    "- `min_limit` gibt an, was das minimale Rekursionslimit sein muss, damit ein State im Cache gespeichert wird"
+    "Die Klasse `Cache` implementiert eine Transpositionstabelle die persistiert werden kann. Der Konstruktor erhält folgenden Parameter: \n",
+    "- `max_size` gibt an, wie viele Einträge sich maximal im Cache befinden dürfen, bevor Einträge mit dem geringsten Rekursionslimit entfernt werden."
    ]
   },
   {
@@ -43,8 +42,7 @@
    "outputs": [],
    "source": [
     "class Cache:\n",
-    "    def __init__(self, max_size = 1_000_000, min_limit = 0):\n",
-    "        self.min_limit = min_limit\n",
+    "    def __init__(self, max_size = 1_000_000):\n",
     "        self.max_size = max_size\n",
     "        self.cache = {}"
    ]
@@ -65,7 +63,7 @@
    "outputs": [],
    "source": [
     "def __repr__(self: Cache) -> str:\n",
-    "    return f\"Cache(size={len(self.cache)}, max_size={self.max_size}, min_limit={self.min_limit})\"\n",
+    "    return f\"Cache(size={len(self.cache)}, max_size={self.max_size})\"\n",
     "\n",
     "Cache.__repr__ = __repr__\n",
     "del __repr__"
@@ -128,13 +126,13 @@
    "id": "67898816",
    "metadata": {},
    "source": [
-    "Die Methode `write` schreibt einen Zustand in den Cache. Dabei wird der Zustand auf den weißen Spieler normiert. Es werden folgende Argumente erwartet:\n",
+    "Die Methode `write` schreibt einen Zustand in die Transpositionstabelle. Dabei wird der Zustand auf den weißen Spieler normiert. Es werden folgende Argumente erwartet:\n",
     "- `state` $\\in States$;\n",
-    "- `player` $\\in Player$.\n",
+    "- `player` $\\in Player$;\n",
     "- `limit` $\\in \\mathbb{N}_0$;\n",
     "- `value` $\\in \\mathopen[-1.0,1.0\\mathclose]$;\n",
     "- `alpha` $\\in \\mathopen[-1.0,1.0\\mathclose]$;\n",
-    "- `beta` $\\in \\mathopen[-1.0,1.0\\mathclose]$;"
+    "- `beta` $\\in \\mathopen[-1.0,1.0\\mathclose]$."
    ]
   },
   {
@@ -144,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def write(self, state, player: str, limit: int, value: float, alpha: float, beta: float) -> None:\n",
+    "def write(self: Cache, state, player: str, limit: int, value: float, alpha: float, beta: float) -> None:\n",
     "    state = convert_state_to_bytes(state, player)\n",
     "    key = state + limit.to_bytes(1,'big')\n",
     "    if player == 'b':\n",
@@ -161,15 +159,15 @@
    "id": "7989ea94",
    "metadata": {},
    "source": [
-    "Die Methode `read` liest einen vorher gespeicherten Zustand aus dem Cache aus. Falls der Zustand nicht vorhanden ist wird `None` zurück gegeben. Dabei wird die Normierung auf den weißen Spieler rückgängig gemacht. Folgende Argumente werden erwartet:\n",
+    "Die Methode `read` liest einen vorher gespeicherten Zustand aus der Transpositionstabelle aus. Falls der Zustand nicht vorhanden ist wird `None` zurück gegeben. Dabei wird die Normierung auf den weißen Spieler rückgängig gemacht. Folgende Argumente werden erwartet:\n",
     "- `state` $\\in States$;\n",
-    "- `player` $\\in Player$.\n",
-    "- `limit` $\\in \\mathbb{N}_0$;\n",
+    "- `player` $\\in Player$;\n",
+    "- `limit` $\\in \\mathbb{N}_0$.\n",
     "\n",
     "Zurückgegeben wird ein Tripel bestehend aus:\n",
     "1. `value` $\\in \\mathopen[-1.0,1.0\\mathclose]$;\n",
     "2. `alpha` $\\in \\mathopen[-1.0,1.0\\mathclose]$;\n",
-    "3. `beta` $\\in \\mathopen[-1.0,1.0\\mathclose]$;"
+    "3. `beta` $\\in \\mathopen[-1.0,1.0\\mathclose]$."
    ]
   },
   {
@@ -179,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def read(self, state, player: str, limit: int) -> (float,float,float):\n",
+    "def read(self: Cache, state, player: str, limit: int) -> (float,float,float):\n",
     "    state = convert_state_to_bytes(state, player)\n",
     "    key = state + limit.to_bytes(1,'big')\n",
     "    result = self.cache.get(key)\n",
@@ -201,7 +199,7 @@
    "id": "385ef884",
    "metadata": {},
    "source": [
-    "Die Methode `clean` prüft ob der Cache seine maximale Größe überschritten hat. Ist dies der Fall wird das minimale Rekursionslimit um eins erhöht und alle Einträge, deren Rekursionslimit geringer ist, werden aus dem Cache entfernt."
+    "Die Methode `clean` prüft ob der Cache seine maximale Größe überschritten hat. Ist dies der Fall werden Einträge beginnend mit dem Rekursionslimit $limit = 0$ aus dem Cache entfernt. Solange die Transpositionstabelle weiterhin ihre maximale Größe überschreitet, wird das minimale Rekursionslimit erhöht und die unterschreitenden Einträge gelöscht."
    ]
   },
   {
@@ -211,19 +209,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def clean(self):\n",
-    "    cleaned = False\n",
+    "def clean(self: Cache):\n",
+    "    min_limit = 0\n",
+    "    \n",
     "    while len(self.cache) > self.max_size:\n",
-    "        self.min_limit += 1\n",
+    "        min_limit += 1\n",
+    "        \n",
     "        pre_len = len(self.cache)\n",
     "        self.cache = {\n",
     "            key: value\n",
     "            for key, value in self.cache.items()\n",
-    "            if key[7] >= self.min_limit\n",
+    "            if key[7] > min_limit\n",
     "        }\n",
-    "        cleaned = True\n",
-    "        print(f\"Increased min_limit to {self.min_limit} and deleted {pre_len - len(self.cache)} entries. Cache is now {len(self.cache)} entries big.\")\n",
-    "    return cleaned\n",
+    "        \n",
+    "        print(f\"Increased min_limit to {min_limit} and deleted {pre_len - len(self.cache)} entries. \" + \\\n",
+    "              f\"Cache is now {len(self.cache)} entries big.\")\n",
+    "    \n",
+    "    return min_limit != 0\n",
+    "\n",
     "Cache.clean = clean\n",
     "del clean"
    ]
@@ -234,7 +237,7 @@
    "metadata": {},
    "source": [
     "Die Methode `save` persistiert den Cache auf dem Dateisystem des Computers. Dafür wird folgendes Argument erwartet:\n",
-    "- `path` beschreibt den Pfad zur Cache-Datei im Dateisystem;"
+    "- `path` beschreibt den Pfad zur Cache-Datei im Dateisystem."
    ]
   },
   {
@@ -244,11 +247,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def save(self, path: str):\n",
+    "def save(self: Cache, path: str):\n",
     "    with open(path, \"wb\") as file:\n",
     "        for key,value in tqdm(self.cache.items()):\n",
     "            file.write(key)\n",
     "            file.write(value)\n",
+    "\n",
     "Cache.save = save\n",
     "del save"
    ]
@@ -259,7 +263,7 @@
    "metadata": {},
    "source": [
     "Die Methode `load` lädt einen vorhandenen Cache basierend auf einer Cache-Datei, die sich auf dem Dateisystem des Computers befindet. Dafür wird folgendes Argument erwartet:\n",
-    "- `path` beschreibt den Pfad zur Cache-Datei im Dateisystem;"
+    "- `path` beschreibt den Pfad zur Cache-Datei im Dateisystem."
    ]
   },
   {
@@ -269,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def load(self, path: str):\n",
+    "def load(self: Cache, path: str):\n",
     "    if not os.path.isfile(path):\n",
     "        return\n",
     "    with open(path, \"rb\") as file:\n",


### PR DESCRIPTION
As every state will be saved inside of the cache, it can grow with
elements which are below the global min_limit. Thus while cleaning the
min_limit will be incremented, even thought deleting the newly added
states would be enought.